### PR TITLE
Added MIME type image/png for credential attributes

### DIFF
--- a/src/Hyperledger.Aries.TestHarness/Scenarios.cs
+++ b/src/Hyperledger.Aries.TestHarness/Scenarios.cs
@@ -110,7 +110,8 @@ namespace Hyperledger.TestHarness
             var offerConfig = offerConfiguration ?? new OfferConfiguration
             {
                 IssuerDid = issuer.Did,
-                CredentialDefinitionId = definitionId
+                CredentialDefinitionId = definitionId,
+                CredentialAttributeValues = credentialAttributes
             };
 
             // Send an offer to the holder using the established connection channel

--- a/src/Hyperledger.Aries/Features/IssueCredential/Models/CredentialMimeTypes.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/Models/CredentialMimeTypes.cs
@@ -14,5 +14,10 @@
         /// Application JSON mime type
         /// </summary>
         public const string ApplicationJsonMimeType = "application/json";
+        
+        /// <summary>
+        /// MIME type for images in PNG format. The content should be a PNG file which is encoded in Base64.
+        /// </summary>
+        public const string ImagePngMimeType = "image/png";
     }
 }

--- a/src/Hyperledger.Aries/Features/PresentProof/Messages/PresentationPreviewMessage.cs
+++ b/src/Hyperledger.Aries/Features/PresentProof/Messages/PresentationPreviewMessage.cs
@@ -51,7 +51,6 @@ namespace Hyperledger.Aries.Features.PresentProof
     /// </summary>
     public class ProposedAttribute
     {
-
         /// <summary>
         /// Gets or sets the name of the Attribute
         /// </summary>

--- a/src/Hyperledger.Aries/Utils/CredentialUtils.cs
+++ b/src/Hyperledger.Aries/Utils/CredentialUtils.cs
@@ -32,6 +32,7 @@ namespace Hyperledger.Aries.Utils
                 {
                     case CredentialMimeTypes.TextMimeType:
                     case CredentialMimeTypes.ApplicationJsonMimeType:
+                    case CredentialMimeTypes.ImagePngMimeType:
                         result.Add(item.Name, FormatStringCredentialAttribute(item));
                         break;
                     default:
@@ -99,6 +100,7 @@ namespace Hyperledger.Aries.Utils
                 case null:
                 case CredentialMimeTypes.TextMimeType:
                 case CredentialMimeTypes.ApplicationJsonMimeType:
+                case CredentialMimeTypes.ImagePngMimeType:
                     break;
                 default:
                     throw new AriesFrameworkException(ErrorCode.InvalidParameterFormat, $"{attribute.Name} mime type of {attribute.MimeType} not supported");
@@ -141,6 +143,7 @@ namespace Hyperledger.Aries.Utils
             {
                 case CredentialMimeTypes.TextMimeType:
                 case CredentialMimeTypes.ApplicationJsonMimeType:
+                case CredentialMimeTypes.ImagePngMimeType:
                     return (string)attributeValue;
                 default:
                     throw new AriesFrameworkException(ErrorCode.InvalidParameterFormat, $"Mime type of {mimeType} not supported");
@@ -161,6 +164,7 @@ namespace Hyperledger.Aries.Utils
                     return attributeValue.Value<string>();
                 case CredentialMimeTypes.TextMimeType:
                 case CredentialMimeTypes.ApplicationJsonMimeType:
+                case CredentialMimeTypes.ImagePngMimeType:
                     return attributeValue.Value<string>();
                 default:
                     throw new AriesFrameworkException(ErrorCode.InvalidParameterFormat, $"Mime type of {mimeType} not supported");

--- a/test/Hyperledger.Aries.Tests/Protocols/CredentialTests.cs
+++ b/test/Hyperledger.Aries.Tests/Protocols/CredentialTests.cs
@@ -129,6 +129,37 @@ namespace Hyperledger.Aries.Tests.Protocols
         }
 
         [Fact]
+        public async Task CanStoreAndReceiveImagePngMimeTypes()
+        {
+            const string pngFile = "base64_encoded_png_image_file";
+            
+            var (issuerConnection, holderConnection) = await Scenarios.EstablishConnectionAsync(
+                _connectionService, _messages, _issuerWallet, _holderWallet);
+
+            var (issuerCredential, holderCredential) = await Scenarios.IssueCredentialAsync(
+                _schemaService, _credentialService, _messages, issuerConnection,
+                holderConnection, _issuerWallet, _holderWallet, await _holderWallet.Pool, TestConstants.DefaultMasterSecret, false, new List<CredentialPreviewAttribute>
+                {
+                    new CredentialPreviewAttribute
+                    {
+                        MimeType = CredentialMimeTypes.ImagePngMimeType,
+                        Name = "preview_image",
+                        Value = pngFile
+                    }
+                });
+
+            var actualResult = string.Empty;
+            foreach (var credentialPreviewAttribute in holderCredential.CredentialAttributesValues)
+            {
+                if (credentialPreviewAttribute.MimeType == CredentialMimeTypes.ImagePngMimeType)
+                    actualResult = credentialPreviewAttribute.Value as string;
+            }
+            
+            Assert.Equal(pngFile, actualResult);
+        }
+        
+
+        [Fact]
         public async Task CanCreateCredentialOffer()
         {
             var issuer = await Did.CreateAndStoreMyDidAsync(_issuerWallet.Wallet,
@@ -216,7 +247,6 @@ namespace Hyperledger.Aries.Tests.Protocols
             Assert.True(ex.ErrorCode == ErrorCode.InvalidParameterFormat);
             Assert.True(ex.Message.Split('\n').Count() == 2);
         }
-
 
         [Fact]
         public async Task RevokeCredentialOfferThrowsCredentialNotFound()


### PR DESCRIPTION
#### Short description of what this resolves:

With this PR, credentials with attributes of MIME type 'image/png' can now be stored and retrieved.

#### Changes proposed in this pull request:

- Added Support for MIME type image/png.
- Value of attributes with MIME type 'image/png' is the image encoded in base64.
- Added Test for storing credential with attributes of MIME type 'image/png'.

**Fixes**: #
