### PR TITLE
adjusted DefaultCredentialHandler for image/png mimetypes

### DIFF
--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialHandler.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialHandler.cs
@@ -155,7 +155,20 @@ namespace Hyperledger.Aries.Features.IssueCredential
             var values = jcred["values"].ToObject<Dictionary<string, AttributeValue>>();
 
             var credential = await _credentialService.GetAsync(agentContext, credentialId);
-            credential.CredentialAttributesValues = values.Select(x => new CredentialPreviewAttribute { Name = x.Key, Value = x.Value.Raw, MimeType = CredentialMimeTypes.TextMimeType }).ToList();
+            var credentialAttributesValues = credential.CredentialAttributesValues.ToList();
+            
+            var result = new List<CredentialPreviewAttribute>();
+            for (var i = 0; i < values.Count; i++)
+            {
+                result.Add(new CredentialPreviewAttribute
+                {
+                    Name = values.ElementAt(i).Key,
+                    Value = values.ElementAt(i).Value.Raw,
+                    MimeType = credentialAttributesValues[i].MimeType
+                });
+            }
+            credential.CredentialAttributesValues = result;
+            
             await _recordService.UpdateAsync(agentContext.Wallet, credential);
 
             return credential;

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialHandler.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialHandler.cs
@@ -158,16 +158,14 @@ namespace Hyperledger.Aries.Features.IssueCredential
             var credentialAttributesValues = credential.CredentialAttributesValues.ToList();
             
             var newCredentialAttributesValues = new List<CredentialPreviewAttribute>();
-            var count = 0;
             foreach (var (key, value) in values)
             {
                 newCredentialAttributesValues.Add(new CredentialPreviewAttribute
                 {
                     Name = key,
                     Value = value.Raw,
-                    MimeType = credentialAttributesValues[count].MimeType ?? CredentialMimeTypes.TextMimeType
+                    MimeType = credentialAttributesValues.FirstOrDefault(x => x.Name == key)?.MimeType ?? CredentialMimeTypes.TextMimeType
                 });
-                count++;
             }
             credential.CredentialAttributesValues = newCredentialAttributesValues;
             

--- a/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialHandler.cs
+++ b/src/Hyperledger.Aries/Features/IssueCredential/DefaultCredentialHandler.cs
@@ -157,17 +157,19 @@ namespace Hyperledger.Aries.Features.IssueCredential
             var credential = await _credentialService.GetAsync(agentContext, credentialId);
             var credentialAttributesValues = credential.CredentialAttributesValues.ToList();
             
-            var result = new List<CredentialPreviewAttribute>();
-            for (var i = 0; i < values.Count; i++)
+            var newCredentialAttributesValues = new List<CredentialPreviewAttribute>();
+            var count = 0;
+            foreach (var (key, value) in values)
             {
-                result.Add(new CredentialPreviewAttribute
+                newCredentialAttributesValues.Add(new CredentialPreviewAttribute
                 {
-                    Name = values.ElementAt(i).Key,
-                    Value = values.ElementAt(i).Value.Raw,
-                    MimeType = credentialAttributesValues[i].MimeType
+                    Name = key,
+                    Value = value.Raw,
+                    MimeType = credentialAttributesValues[count].MimeType ?? CredentialMimeTypes.TextMimeType
                 });
+                count++;
             }
-            credential.CredentialAttributesValues = result;
+            credential.CredentialAttributesValues = newCredentialAttributesValues;
             
             await _recordService.UpdateAsync(agentContext.Wallet, credential);
 


### PR DESCRIPTION
Signed-off-by: Dindexx <kevin.dinh@main-incubator.com>

#### Short description of what this resolves:
Mime-type for issued credentials was hard coded in `UpdateValues()` to text/plain, which caused every credential in the wallet to have text/plain as the mimetype. This PR resolves that issue.

#### Changes proposed in this pull request:

- Changed `UpdateValues()` in `DefaultCredentialHandler`
-
-

**Fixes**: #
