### PR TITLE
DefaulProofService BuildRevocationStatesFix

### DIFF
--- a/src/Hyperledger.Aries/Features/PresentProof/DefaultProofService.cs
+++ b/src/Hyperledger.Aries/Features/PresentProof/DefaultProofService.cs
@@ -859,6 +859,9 @@ namespace Hyperledger.Aries.Features.PresentProof
                 foreach (var proofRequestRequestedAttribute in proofRequest.RequestedAttributes)
                 {
                     var revocationInterval = proofRequestRequestedAttribute.Value.NonRevoked;
+                    if (revocationInterval == null)
+                        continue;
+                    
                     var (delta, state) = await BuildRevocationStateAsync(
                         agentContext, credential, registryDefinition, revocationInterval);
                     
@@ -873,6 +876,9 @@ namespace Hyperledger.Aries.Features.PresentProof
                 foreach (var proofRequestRequestedPredicate in proofRequest.RequestedPredicates)
                 {
                     var revocationInterval = proofRequestRequestedPredicate.Value.NonRevoked;
+                    if (revocationInterval == null)
+                        continue;
+                    
                     var (delta, state) = await BuildRevocationStateAsync(
                         agentContext, credential, registryDefinition, revocationInterval);
                     


### PR DESCRIPTION
Signed-off-by: Dindexx <kevin.dinh@main-incubator.com>

#### Short description of what this resolves:
Issue where a proof that consists of a combination of attributes with checks for NonRevoked and attributes without checks for NonRevoked couldnt be processed.

#### Changes proposed in this pull request:

- Dont build revocation state for attributes where NonRevoked was not set
