### PR TITLE
support different uri types for metadata

### DIFF
--- a/src/Hyperledger.Aries/Features/OpenID4VC/KeyStore/Services/IKeyStore.cs
+++ b/src/Hyperledger.Aries/Features/OpenID4VC/KeyStore/Services/IKeyStore.cs
@@ -24,11 +24,12 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.KeyStore.Services
         /// <param name="nonce">
         ///     A unique token, typically used to prevent replay attacks by ensuring that the proof is only used once.
         /// </param>
+        /// <param name="type">The type of the proof. (For example "openid4vci-proof+jwt")</param>
         /// <returns>
         ///     A <see cref="Task{TResult}" /> representing the asynchronous operation. When evaluated, the task's result contains
         ///     the proof.
         /// </returns>
-        Task<string> GenerateProofOfPossessionAsync(string keyId, string audience, string nonce);
+        Task<string> GenerateProofOfPossessionAsync(string keyId, string audience, string nonce, string type);
 
         /// <summary>
         ///     Asynchronously loads a key by its identifier and returns it as a JSON Web Key (JWK) containing the public key

--- a/src/Hyperledger.Aries/Features/OpenID4VC/VCI/Services/Oid4VciClientService/DefaultOid4VciClientService.cs
+++ b/src/Hyperledger.Aries/Features/OpenID4VC/VCI/Services/Oid4VciClientService/DefaultOid4VciClientService.cs
@@ -69,7 +69,7 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vci.Services.Oid4VciClientService
         {
             var keyId = await _keyStore.GenerateKey();
             var proofOfPossession = await _keyStore.GenerateProofOfPossessionAsync(
-                keyId, credentialIssuer, clientNonce);
+                keyId, credentialIssuer, clientNonce, "openid4vci-proof+jwt");
 
             var credentialRequest = new OidCredentialRequest
             {

--- a/src/Hyperledger.Aries/Features/OpenID4VC/VCI/Services/Oid4VciClientService/DefaultOid4VciClientService.cs
+++ b/src/Hyperledger.Aries/Features/OpenID4VC/VCI/Services/Oid4VciClientService/DefaultOid4VciClientService.cs
@@ -41,16 +41,20 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vci.Services.Oid4VciClientService
         public virtual async Task<OidIssuerMetadata> FetchIssuerMetadataAsync(Uri endpoint)
         {
             var httpClient = _httpClientFactory.CreateClient();
-            var metadataUrl = new Uri(endpoint, ".well-known/openid-credential-issuer");
+            
+            var baseEndpoint = endpoint.AbsolutePath.EndsWith("/") ? endpoint : new Uri(endpoint.OriginalString + "/");
+            var metadataUrl = new Uri(baseEndpoint, ".well-known/openid-credential-issuer");
 
             var response = await httpClient.GetAsync(metadataUrl);
             var responseString = await response.Content.ReadAsStringAsync();
 
             if (response.IsSuccessStatusCode)
+            {
                 return JsonConvert.DeserializeObject<OidIssuerMetadata>(responseString)
                        ?? throw new InvalidOperationException(
                            "Failed to deserialize the issuer metadata. JSON: " +
                            responseString);
+            }
 
             throw new HttpRequestException(
                 $"Failed to get Issuer metadata. Status code is {response.StatusCode} with message {responseString}");
@@ -67,13 +71,25 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vci.Services.Oid4VciClientService
             var proofOfPossession = await _keyStore.GenerateProofOfPossessionAsync(
                 keyId, credentialIssuer, clientNonce);
 
-            var credentialRequest = BuildCredentialRequest(proofOfPossession, type);
+            var credentialRequest = new OidCredentialRequest
+            {
+                Format = "vc+sd-jwt",
+                Type = type,
+                Proof = new OidProofOfPossession
+                {
+                    ProofType = "jwt",
+                    Jwt = proofOfPossession
+                }
+            };
+
             var responseData = await SendCredentialRequest(credentialIssuer, tokenResponse, credentialRequest);
 
             var responseString = await responseData.Content.ReadAsStringAsync();
             if (!responseData.IsSuccessStatusCode)
+            {
                 throw new HttpRequestException(
                     $"Failed to request Credential. Status Code is {responseData.StatusCode} with message {responseString}");
+            }
 
             var credentialResponse = JsonConvert.DeserializeObject<OidCredentialResponse>(responseString)
                                      ?? throw new InvalidOperationException(
@@ -81,7 +97,9 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vci.Services.Oid4VciClientService
                                          responseString);
 
             if (credentialResponse.Credential == null)
+            {
                 throw new InvalidOperationException("Credential in response is null.");
+            }
 
             return (credentialResponse, keyId);
         }
@@ -91,25 +109,7 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vci.Services.Oid4VciClientService
             string? pin = null)
         {
             var authServer = await GetAuthorizationServerMetadata(metadata);
-            return await GetRequestTokenAsync(preAuthorizedCode, authServer, pin);
-        }
 
-        private static OidCredentialRequest BuildCredentialRequest(string jwt, string type)
-        {
-            return new OidCredentialRequest
-            {
-                Format = "vc+sd-jwt",
-                Type = type,
-                Proof = new OidProofOfPossession
-                {
-                    ProofType = "jwt",
-                    Jwt = jwt
-                }
-            };
-        }
-
-        private static Task<FormUrlEncodedContent> CreateRequestToken(string preAuthorizedCode, string? pin)
-        {
             var tokenRequest = new TokenRequest
             {
                 GrantType = "urn:ietf:params:oauth:grant-type:pre-authorized_code",
@@ -117,60 +117,63 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vci.Services.Oid4VciClientService
             };
 
             if (!string.IsNullOrEmpty(pin))
+            {
                 tokenRequest.UserPin = pin;
+            }
 
-            return Task.FromResult(tokenRequest.ToFormUrlEncoded());
+            var formUrlEncodedRequest = tokenRequest.ToFormUrlEncoded();
+
+            var httpClient = _httpClientFactory.CreateClient();
+            var response = await httpClient.PostAsync(authServer.TokenEndpoint, formUrlEncodedRequest);
+            var responseString = await response.Content.ReadAsStringAsync();
+
+            if (response.IsSuccessStatusCode)
+            {
+                return JsonConvert.DeserializeObject<TokenResponse>(responseString) ??
+                       throw new InvalidOperationException("Failed to deserialize the token response. JSON: " +
+                                                           responseString);
+            }
+
+            throw new HttpRequestException(
+                $"Failed to get token. Status Code is {response.StatusCode} with message {responseString}");
         }
 
-        private async Task<AuthorizationServerMetadata> FetchAuthorizationServerMetadataAsync(string endpointUrl)
+        private async Task<AuthorizationServerMetadata> GetAuthorizationServerMetadata(OidIssuerMetadata metadata)
         {
+            var endpointUrl = GetAuthorizationServerUrl(metadata);
+
             var httpClient = _httpClientFactory.CreateClient();
             var response = await httpClient.GetAsync(endpointUrl);
             var responseString = await response.Content.ReadAsStringAsync();
 
             if (response.IsSuccessStatusCode)
+            {
                 return JsonConvert.DeserializeObject<AuthorizationServerMetadata>(responseString)
                        ?? throw new InvalidOperationException(
                            "Failed to deserialize the authorization server metadata. JSON: " + responseString);
+            }
 
             throw new HttpRequestException(
                 $"Failed to get authorization server metadata. Status Code is: {response.StatusCode} with message {responseString}");
         }
 
-        private async Task<AuthorizationServerMetadata> GetAuthorizationServerMetadata(OidIssuerMetadata metadata)
+        private static string GetAuthorizationServerUrl(OidIssuerMetadata metadata)
         {
-            string endpointUrl;
             if (!string.IsNullOrEmpty(metadata.AuthorizationServer))
             {
-                endpointUrl = metadata.AuthorizationServer;
+                return metadata.AuthorizationServer;
             }
-            else
+
+            var credentialIssuerUrl = new Uri(metadata.CredentialIssuer);
+            if (string.IsNullOrEmpty(credentialIssuerUrl.AbsolutePath) || credentialIssuerUrl.AbsolutePath == "/")
             {
-                var credentialIssuerUrl = new Uri(metadata.CredentialIssuer);
-                endpointUrl = new Uri(credentialIssuerUrl, "/.well-known/oauth-authorization-server").ToString();
+                return
+                    $"{credentialIssuerUrl.GetLeftPart(UriPartial.Authority)}/.well-known/oauth-authorization-server";
             }
 
-            return await FetchAuthorizationServerMetadataAsync(endpointUrl);
-        }
-
-        private async Task<TokenResponse> GetRequestTokenAsync(
-            string preAuthorizedCode,
-            AuthorizationServerMetadata? authorizationServer,
-            string? pin = null)
-        {
-            var formUrlEncodedRequest = await CreateRequestToken(preAuthorizedCode, pin);
-
-            var httpClient = _httpClientFactory.CreateClient();
-            var response = await httpClient.PostAsync(authorizationServer?.TokenEndpoint, formUrlEncodedRequest);
-            var responseString = await response.Content.ReadAsStringAsync();
-
-            if (response.IsSuccessStatusCode)
-                return JsonConvert.DeserializeObject<TokenResponse>(responseString) ??
-                       throw new InvalidOperationException("Failed to deserialize the token response. JSON: " +
-                                                           responseString);
-
-            throw new HttpRequestException(
-                $"Failed to get token. Status Code is {response.StatusCode} with message {responseString}");
+            var trimmedPath = credentialIssuerUrl.AbsolutePath.TrimEnd('/');
+            return
+                $"{credentialIssuerUrl.GetLeftPart(UriPartial.Authority)}/.well-known/oauth-authorization-server{trimmedPath}";
         }
 
         private async Task<HttpResponseMessage> SendCredentialRequest(
@@ -181,9 +184,9 @@ namespace Hyperledger.Aries.Features.OpenId4Vc.Vci.Services.Oid4VciClientService
             var requestData = new StringContent(credentialRequest.ToJson(), Encoding.UTF8, "application/json");
 
             var httpClientWithAuth = _httpClientFactory.CreateClient();
-            
+
             httpClientWithAuth.DefaultRequestHeaders.Remove("Authorization");
-            
+
             httpClientWithAuth.DefaultRequestHeaders.Add("Authorization",
                 $"{tokenResponse.TokenType} {tokenResponse.AccessToken}");
 

--- a/test/Hyperledger.Aries.Tests/Features/OpenId4Vc/Vci/Services/DefaultOid4VciClientServiceTests.cs
+++ b/test/Hyperledger.Aries.Tests/Features/OpenId4Vc/Vci/Services/DefaultOid4VciClientServiceTests.cs
@@ -21,14 +21,45 @@ namespace Hyperledger.Aries.Tests.Features.OpenId4Vc.Vci.Services
 {
     public class DefaultOid4VciClientServiceTests
     {
+        private const string AuthServerMetadata =
+            "{\"issuer\":\"https://issuer.io\",\"token_endpoint\":\"https://issuer.io/token\",\"token_endpoint_auth_methods_supported\":[\"urn:ietf:params:oauth:client-assertion-type:verifiable-presentation\"],\"response_types_supported\":[\"urn:ietf:params:oauth:grant-type:pre-authorized_code\"]}\n";
+
         private const string CredentialType = "VerifiedEmail";
-        
+
+        private const string IssuerMetadataResponseContent =
+            "{\"credential_issuer\":\"https://issuer.io/\",\"credential_endpoint\":\"https://issuer.io/credential\",\"display\":[{\"name\":\"Aussteller\",\"locale\":\"de-DE\"},{\"name\":\"Issuer\",\"locale\":\"en-US\"}],\"credentials_supported\":[{\"format\":\"vc+sd-jwt\",\"id\":\"VerifiedEMail\",\"cryptographic_binding_methods_supported\":[\"jwk\"],\"cryptographic_suites_supported\":[\"ES256\"],\"type\":\"VerifiedEMail\",\"display\":[{\"name\":\"Verifizierte eMail-Adresse\",\"logo\":{\"url\":\"https://issuer.io/logo.png\",\"alternative_text\":\"Logo\"},\"text_color\":\"#FFFFFF\",\"background_color\":\"#12107c\",\"locale\":\"de-DE\"},{\"name\":\"Verified eMail address\",\"logo\":{\"url\":\"https://issuer.io/logo.png\",\"alternative_text\":\"Logo\"},\"text_color\":\"#FFFFFF\",\"background_color\":\"#12107c\",\"locale\":\"en-US\"}],\"credentialSubject\":{\"given_name\":{\"display\":[{\"locale\":\"de-DE\",\"name\":\"Vorname\"},{\"locale\":\"en-US\",\"name\":\"Given name\"}]},\"last_name\":{\"display\":[{\"locale\":\"de-DE\",\"name\":\"Nachname\"},{\"locale\":\"en-US\",\"name\":\"Surname\"}]},\"email\":{\"display\":[{\"locale\":\"de-DE\",\"name\":\"E-Mail Adresse\"},{\"locale\":\"en-US\",\"name\":\"e-Mail address\"}]}}},{\"format\":\"vc+sd-jwt\",\"id\":\"AttestedVerifiedEMail\",\"cryptographic_binding_methods_supported\":[\"jwk\"],\"cryptographic_suites_supported\":[\"ES256\"],\"type\":\"AttestedVerifiedEMail\",\"display\":[{\"name\":\"Verifizierte eMail-Adresse\",\"logo\":{\"url\":\"https://issuer.io/logo.png\",\"alternative_text\":\"Logo\"},\"text_color\":\"#FFFFFF\",\"background_color\":\"#12107c\",\"locale\":\"de-DE\"},{\"name\":\"Verified eMail address\",\"logo\":{\"url\":\"https://issuer.io/logo.png\",\"alternative_text\":\"Logo\"},\"text_color\":\"#FFFFFF\",\"background_color\":\"#12107c\",\"locale\":\"en-US\"}],\"credentialSubject\":{\"given_name\":{\"display\":[{\"locale\":\"de-DE\",\"name\":\"Vorname\"},{\"locale\":\"en-US\",\"name\":\"Given name\"}]},\"last_name\":{\"display\":[{\"locale\":\"de-DE\",\"name\":\"Nachname\"},{\"locale\":\"en-US\",\"name\":\"Surname\"}]},\"email\":{\"display\":[{\"locale\":\"de-DE\",\"name\":\"E-Mail Adresse\"},{\"locale\":\"en-US\",\"name\":\"e-Mail address\"}]}}}]}";
+
+        private const string PreAuthorizedCode = "1234";
+
+        private const string TokenResponse =
+            "{\"access_token\":\"eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp..sHQ\",\"token_type\":\"bearer\",\"expires_in\": 86400,\"c_nonce\": \"tZignsnFbp\",\"c_nonce_expires_in\":86400}";
+
         private DefaultOid4VciClientService _oid4VciClientService;
+
+        private readonly HttpResponseMessage _authServerMetadataResponse = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(AuthServerMetadata)
+        };
+
+        private readonly HttpResponseMessage _issuerMetadataResponse = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(IssuerMetadataResponseContent)
+        };
+
+        private readonly HttpResponseMessage _tokenResponse = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(TokenResponse)
+        };
+
         private readonly Mock<HttpMessageHandler> _httpMessageHandlerMock = new Mock<HttpMessageHandler>();
         private readonly Mock<IHttpClientFactory> _httpClientFactoryMock = new Mock<IHttpClientFactory>();
         private readonly Mock<IKeyStore> _keyStoreMock = new Mock<IKeyStore>();
 
-        private readonly OidIssuerMetadata _oidIssuerMetadata = new OidIssuerMetadata{
+        private readonly OidIssuerMetadata _oidIssuerMetadata = new OidIssuerMetadata
+        {
             CredentialIssuer = "https://issuer.io",
             CredentialEndpoint = "https://issuer.io/credential",
             CredentialsSupported = new List<OidCredentialMetadata>
@@ -43,18 +74,58 @@ namespace Hyperledger.Aries.Tests.Features.OpenId4Vc.Vci.Services
         };
 
         [Fact]
+        public async Task AuthServerUriIsBuiltCorrectly()
+        {
+            // Arrange
+            const string authServerUri = "https://authserver.io";
+            _oidIssuerMetadata.AuthorizationServer = authServerUri;
+
+            SetupHttpClientSequence(_authServerMetadataResponse, _tokenResponse);
+
+            var expectedUri = new Uri(authServerUri);
+
+            // Act
+            await _oid4VciClientService.RequestTokenAsync(_oidIssuerMetadata, PreAuthorizedCode);
+
+            // Assert
+            _httpMessageHandlerMock.Protected()
+                .Verify("SendAsync", Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(req =>
+                        req.Method == HttpMethod.Get && req.RequestUri == expectedUri),
+                    ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Theory]
+        [InlineData("https://issuer.io", "https://issuer.io/.well-known/oauth-authorization-server")]
+        [InlineData("https://issuer.io/issuer1", "https://issuer.io/.well-known/oauth-authorization-server/issuer1")]
+        public async Task AuthServerUriIsBuiltFromCredentialIssuerCorrectly(string issuer, string expectedUriString)
+        {
+            // Arrange
+            _oidIssuerMetadata.CredentialIssuer = issuer;
+
+            SetupHttpClientSequence(_authServerMetadataResponse, _tokenResponse);
+
+            var expectedUri = new Uri(expectedUriString);
+
+            // Act
+            await _oid4VciClientService.RequestTokenAsync(_oidIssuerMetadata, PreAuthorizedCode);
+
+            // Assert
+            _httpMessageHandlerMock.Protected()
+                .Verify("SendAsync", Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(req =>
+                        req.Method == HttpMethod.Get && req.RequestUri == expectedUri),
+                    ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
         public async Task CanGetIssuerMetadataAsync()
         {
             // Arrange
-            const string responseContent = "{\"credential_issuer\":\"https://issuer.io/\",\"credential_endpoint\":\"https://issuer.io/credential\",\"display\":[{\"name\":\"Aussteller\",\"locale\":\"de-DE\"},{\"name\":\"Issuer\",\"locale\":\"en-US\"}],\"credentials_supported\":[{\"format\":\"vc+sd-jwt\",\"id\":\"VerifiedEMail\",\"cryptographic_binding_methods_supported\":[\"jwk\"],\"cryptographic_suites_supported\":[\"ES256\"],\"type\":\"VerifiedEMail\",\"display\":[{\"name\":\"Verifizierte eMail-Adresse\",\"logo\":{\"url\":\"https://issuer.io/logo.png\",\"alternative_text\":\"Logo\"},\"text_color\":\"#FFFFFF\",\"background_color\":\"#12107c\",\"locale\":\"de-DE\"},{\"name\":\"Verified eMail address\",\"logo\":{\"url\":\"https://issuer.io/logo.png\",\"alternative_text\":\"Logo\"},\"text_color\":\"#FFFFFF\",\"background_color\":\"#12107c\",\"locale\":\"en-US\"}],\"credentialSubject\":{\"given_name\":{\"display\":[{\"locale\":\"de-DE\",\"name\":\"Vorname\"},{\"locale\":\"en-US\",\"name\":\"Given name\"}]},\"last_name\":{\"display\":[{\"locale\":\"de-DE\",\"name\":\"Nachname\"},{\"locale\":\"en-US\",\"name\":\"Surname\"}]},\"email\":{\"display\":[{\"locale\":\"de-DE\",\"name\":\"E-Mail Adresse\"},{\"locale\":\"en-US\",\"name\":\"e-Mail address\"}]}}},{\"format\":\"vc+sd-jwt\",\"id\":\"AttestedVerifiedEMail\",\"cryptographic_binding_methods_supported\":[\"jwk\"],\"cryptographic_suites_supported\":[\"ES256\"],\"type\":\"AttestedVerifiedEMail\",\"display\":[{\"name\":\"Verifizierte eMail-Adresse\",\"logo\":{\"url\":\"https://issuer.io/logo.png\",\"alternative_text\":\"Logo\"},\"text_color\":\"#FFFFFF\",\"background_color\":\"#12107c\",\"locale\":\"de-DE\"},{\"name\":\"Verified eMail address\",\"logo\":{\"url\":\"https://issuer.io/logo.png\",\"alternative_text\":\"Logo\"},\"text_color\":\"#FFFFFF\",\"background_color\":\"#12107c\",\"locale\":\"en-US\"}],\"credentialSubject\":{\"given_name\":{\"display\":[{\"locale\":\"de-DE\",\"name\":\"Vorname\"},{\"locale\":\"en-US\",\"name\":\"Given name\"}]},\"last_name\":{\"display\":[{\"locale\":\"de-DE\",\"name\":\"Nachname\"},{\"locale\":\"en-US\",\"name\":\"Surname\"}]},\"email\":{\"display\":[{\"locale\":\"de-DE\",\"name\":\"E-Mail Adresse\"},{\"locale\":\"en-US\",\"name\":\"e-Mail address\"}]}}}]}";
-            SetupHttpClientSequence(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent(responseContent)
-            });
-            
-            var expectedMetadata = JsonConvert.DeserializeObject<OidIssuerMetadata>(responseContent);
-            
+            SetupHttpClientSequence(_issuerMetadataResponse);
+
+            var expectedMetadata = JsonConvert.DeserializeObject<OidIssuerMetadata>(IssuerMetadataResponseContent);
+
             // Act
             var actualMetadata = await _oid4VciClientService.FetchIssuerMetadataAsync(new Uri("https://issuer.io"));
 
@@ -68,13 +139,15 @@ namespace Hyperledger.Aries.Tests.Features.OpenId4Vc.Vci.Services
             // Arrange
             const string jwtMock = "mockJwt";
             const string keyId = "keyId";
-            
+
             _keyStoreMock.Setup(j => j.GenerateKey(It.IsAny<string>()))
                 .ReturnsAsync(keyId);
-            _keyStoreMock.Setup(j => j.GenerateProofOfPossessionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            _keyStoreMock.Setup(j =>
+                    j.GenerateProofOfPossessionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(jwtMock);
-            
-            const string credentialResponse = "{\"format\":\"vc+sd-jwt\",\"credential\":\"eyJhbGciOiAiRVMyNTYifQ.eyJfc2QiOlsiT0dfT2lCMk5ZS0JzTVhIOFVVb2luREhUT1h5VER1Z3JPdE94RFI2NF9ZcyIsIlQzbHRYQUFtODNJTXRUYkRTb1J2d1g2Tk10em1scV9ZWG9Vd1EwZDY0NEUiXSwiaXNzIjoiaHR0cHM6Ly9pc3N1ZXIuaW8vIiwiaWF0IjoxNTE2MjM5MDIyLCJ0eXBlIjoiVmVyaWZpZWRFbWFpbCIsImV4cCI6MTUxNjI0NzAyMiwiX3NkX2FsZyI6InNoYS0yNTYiLCJjbmYiOnsiandrIjp7Imt0eSI6IkVDIiwiY3J2IjoiUC0yNTYiLCJ4IjoiVENBRVIxOVp2dTNPSEY0ajRXNHZmU1ZvSElQMUlMaWxEbHM3dkNlR2VtYyIsInkiOiJaeGppV1diWk1RR0hWV0tWUTRoYlNJaXJzVmZ1ZWNDRTZ0NGpUOUYySFpRIn19LCJhbGciOiJFUzI1NiJ9.OVSoCqHZLgAPaYK27gJx6J1ejwskP62xIHryqc1ZJYOR8yZdicSF4KXBk5qgocWZdiqEsri5Q3sW69xIfbmXSA~WyJseVMxN1ZzenNGb3doaFBnY3VuOTFRIiwgImV4cCIsIDE1NDE0OTQ3MjRd~WyJaRmNwSWxTNlJ5eWV2U3JTeFdJbDZRIiwgImdpdmVuX25hbWUiLCAiSm9obiJd~WyJVSHVVVUNlOWZzNUdody1mZ0JJWi13IiwgImZhbWlseV9uYW1lIiwgIkRvZSJd~WyJ3ZnR5YkpzYktzVWJDay1XaWpaQ3RRIiwgImVtYWlsIiwgInRlc3RAZXhhbXBsZS5jb20iXQ\"}";
+
+            const string credentialResponse =
+                "{\"format\":\"vc+sd-jwt\",\"credential\":\"eyJhbGciOiAiRVMyNTYifQ.eyJfc2QiOlsiT0dfT2lCMk5ZS0JzTVhIOFVVb2luREhUT1h5VER1Z3JPdE94RFI2NF9ZcyIsIlQzbHRYQUFtODNJTXRUYkRTb1J2d1g2Tk10em1scV9ZWG9Vd1EwZDY0NEUiXSwiaXNzIjoiaHR0cHM6Ly9pc3N1ZXIuaW8vIiwiaWF0IjoxNTE2MjM5MDIyLCJ0eXBlIjoiVmVyaWZpZWRFbWFpbCIsImV4cCI6MTUxNjI0NzAyMiwiX3NkX2FsZyI6InNoYS0yNTYiLCJjbmYiOnsiandrIjp7Imt0eSI6IkVDIiwiY3J2IjoiUC0yNTYiLCJ4IjoiVENBRVIxOVp2dTNPSEY0ajRXNHZmU1ZvSElQMUlMaWxEbHM3dkNlR2VtYyIsInkiOiJaeGppV1diWk1RR0hWV0tWUTRoYlNJaXJzVmZ1ZWNDRTZ0NGpUOUYySFpRIn19LCJhbGciOiJFUzI1NiJ9.OVSoCqHZLgAPaYK27gJx6J1ejwskP62xIHryqc1ZJYOR8yZdicSF4KXBk5qgocWZdiqEsri5Q3sW69xIfbmXSA~WyJseVMxN1ZzenNGb3doaFBnY3VuOTFRIiwgImV4cCIsIDE1NDE0OTQ3MjRd~WyJaRmNwSWxTNlJ5eWV2U3JTeFdJbDZRIiwgImdpdmVuX25hbWUiLCAiSm9obiJd~WyJVSHVVVUNlOWZzNUdody1mZ0JJWi13IiwgImZhbWlseV9uYW1lIiwgIkRvZSJd~WyJ3ZnR5YkpzYktzVWJDay1XaWpaQ3RRIiwgImVtYWlsIiwgInRlc3RAZXhhbXBsZS5jb20iXQ\"}";
             SetupHttpClientSequence(
                 new HttpResponseMessage
                 {
@@ -110,31 +183,38 @@ namespace Hyperledger.Aries.Tests.Features.OpenId4Vc.Vci.Services
         public async Task CanRequestTokenAsync()
         {
             // Arrange
-            const string tokenResponse = "{\"access_token\":\"eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp..sHQ\",\"token_type\":\"bearer\",\"expires_in\": 86400,\"c_nonce\": \"tZignsnFbp\",\"c_nonce_expires_in\":86400}";
-
-            const string authServerMetadata =
-                "{\"issuer\":\"https://issuer.io\",\"token_endpoint\":\"https://issuer.io/token\",\"token_endpoint_auth_methods_supported\":[\"urn:ietf:params:oauth:client-assertion-type:verifiable-presentation\"],\"response_types_supported\":[\"urn:ietf:params:oauth:grant-type:pre-authorized_code\"]}\n";
-
-            var expectedTokenResponse = JsonConvert.DeserializeObject<TokenResponse>(tokenResponse);
-
             SetupHttpClientSequence(
-                new HttpResponseMessage
-                {
-                    StatusCode = HttpStatusCode.OK,
-                    Content = new StringContent(authServerMetadata)
-                },
-                new HttpResponseMessage
-                {
-                    StatusCode = HttpStatusCode.OK,
-                    Content = new StringContent(tokenResponse)
-                });
+                _authServerMetadataResponse,
+                _tokenResponse);
+
+            var expectedTokenResponse = JsonConvert.DeserializeObject<TokenResponse>(TokenResponse);
 
             // Act
             var actualTokenResponse =
-                await _oid4VciClientService.RequestTokenAsync(_oidIssuerMetadata, "samplePreAuthorizedCode");
+                await _oid4VciClientService.RequestTokenAsync(_oidIssuerMetadata, PreAuthorizedCode);
 
             // Assert
             actualTokenResponse.Should().BeEquivalentTo(expectedTokenResponse);
+        }
+
+        [Theory]
+        [InlineData("https://issuer.io", "https://issuer.io/.well-known/openid-credential-issuer")]
+        [InlineData("https://issuer.io/issuer1", "https://issuer.io/issuer1/.well-known/openid-credential-issuer")]
+        public async Task CredentialIssuerUriIsBuiltCorrectly(string inputUri, string expectedUriString)
+        {
+            // Arrange
+            SetupHttpClientSequence(_issuerMetadataResponse);
+
+            // Act
+            var expectedUri = new Uri(expectedUriString);
+            await _oid4VciClientService.FetchIssuerMetadataAsync(new Uri(inputUri));
+
+            // Assert
+            _httpMessageHandlerMock.Protected()
+                .Verify("SendAsync", Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(req =>
+                        req.Method == HttpMethod.Get && req.RequestUri == expectedUri),
+                    ItExpr.IsAny<CancellationToken>());
         }
 
         private void SetupHttpClientSequence(params HttpResponseMessage[] responses)
@@ -149,7 +229,8 @@ namespace Hyperledger.Aries.Tests.Features.OpenId4Vc.Vci.Services
             var httpClient = new HttpClient(_httpMessageHandlerMock.Object);
             _httpClientFactoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
 
-            _oid4VciClientService = new DefaultOid4VciClientService(_httpClientFactoryMock.Object, _keyStoreMock.Object);
+            _oid4VciClientService =
+                new DefaultOid4VciClientService(_httpClientFactoryMock.Object, _keyStoreMock.Object);
         }
     }
 }

--- a/test/Hyperledger.Aries.Tests/Features/OpenId4Vc/Vci/Services/DefaultOid4VciClientServiceTests.cs
+++ b/test/Hyperledger.Aries.Tests/Features/OpenId4Vc/Vci/Services/DefaultOid4VciClientServiceTests.cs
@@ -97,7 +97,9 @@ namespace Hyperledger.Aries.Tests.Features.OpenId4Vc.Vci.Services
 
         [Theory]
         [InlineData("https://issuer.io", "https://issuer.io/.well-known/oauth-authorization-server")]
+        [InlineData("https://issuer.io/", "https://issuer.io/.well-known/oauth-authorization-server")]
         [InlineData("https://issuer.io/issuer1", "https://issuer.io/.well-known/oauth-authorization-server/issuer1")]
+        [InlineData("https://issuer.io/issuer1/", "https://issuer.io/.well-known/oauth-authorization-server/issuer1")]
         public async Task AuthServerUriIsBuiltFromCredentialIssuerCorrectly(string issuer, string expectedUriString)
         {
             // Arrange
@@ -143,7 +145,7 @@ namespace Hyperledger.Aries.Tests.Features.OpenId4Vc.Vci.Services
             _keyStoreMock.Setup(j => j.GenerateKey(It.IsAny<string>()))
                 .ReturnsAsync(keyId);
             _keyStoreMock.Setup(j =>
-                    j.GenerateProofOfPossessionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                    j.GenerateProofOfPossessionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(jwtMock);
 
             const string credentialResponse =
@@ -199,7 +201,9 @@ namespace Hyperledger.Aries.Tests.Features.OpenId4Vc.Vci.Services
 
         [Theory]
         [InlineData("https://issuer.io", "https://issuer.io/.well-known/openid-credential-issuer")]
+        [InlineData("https://issuer.io/", "https://issuer.io/.well-known/openid-credential-issuer")]
         [InlineData("https://issuer.io/issuer1", "https://issuer.io/issuer1/.well-known/openid-credential-issuer")]
+        [InlineData("https://issuer.io/issuer1/", "https://issuer.io/issuer1/.well-known/openid-credential-issuer")]
         public async Task CredentialIssuerUriIsBuiltCorrectly(string inputUri, string expectedUriString)
         {
             // Arrange


### PR DESCRIPTION
#### Short description of what this resolves:

Add support for different types of URI for fetching issuer metadata and oauth-server.

https://datatracker.ietf.org/doc/html/rfc8414#section-3.1

https://openid.bitbucket.io/connect/openid-4-verifiable-credential-issuance-1_0.html#section-10.2.2

#### Changes proposed in this pull request:

- Add support for different types of URI
- Add tests for this particular feature

**Fixes**: #
