### PR TITLE
implement & test PexService

### DIFF
--- a/src/Hyperledger.Aries/Features/Pex/Models/CredentialDescriptor.cs
+++ b/src/Hyperledger.Aries/Features/Pex/Models/CredentialDescriptor.cs
@@ -1,15 +1,13 @@
 namespace Hyperledger.Aries.Features.Pex.Models
 {
-    public class CredentialDescriptor
+    /// <summary>
+    /// The credential descriptor.
+    /// </summary>
+    public class CredentialDescriptor : Descriptor
     {
-        public string InputDescriptorId { get; set; }
-        
-        public string CredentialId { get; set; }
-        
-        public string Format { get; set; }
-        
-        public string Path { get; set; }
-        
-        public CredentialDescriptor? PathNested { get; set; }
+        /// <summary>
+        /// This MUST be the id value of a credential.
+        /// </summary>
+        public string CredentialId { get; set; } = null!;
     }
 }

--- a/src/Hyperledger.Aries/Features/Pex/Models/Descriptor.cs
+++ b/src/Hyperledger.Aries/Features/Pex/Models/Descriptor.cs
@@ -1,0 +1,35 @@
+using Newtonsoft.Json;
+
+namespace Hyperledger.Aries.Features.Pex.Models
+{
+    /// <summary>
+    /// The descriptor.
+    /// </summary>
+    public class Descriptor
+    {
+        /// <summary>
+        /// This MUST be a string that matches the id property of the Input Descriptor in the Presentation Definition that this Presentation Submission is related to.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; } = null!;
+
+        /// <summary>
+        /// This MUST be a string that matches one of the Claim Format Designation
+        /// </summary>
+        [JsonProperty("format")]
+        public string Format { get; set; } = null!;
+
+        /// <summary>
+        /// This MUST be a JSONPath string expression.
+        /// The path property indicates the Claim submitted in relation to the identified Input Descriptor, when executed against the top-level of the object the Presentation Submission is embedded within.
+        /// </summary>
+        [JsonProperty("path")]
+        public string Path { get; set; } = null!;
+        
+        /// <summary>
+        /// This indicate the presence of a multi-Claim envelope format. This means the Claim indicated is to be decoded separately from its parent enclosure
+        /// </summary>
+        [JsonProperty("path_nested")]
+        public Descriptor? PathNested { get; set; }
+    }
+}

--- a/src/Hyperledger.Aries/Features/Pex/Models/Format.cs
+++ b/src/Hyperledger.Aries/Features/Pex/Models/Format.cs
@@ -1,0 +1,22 @@
+using Newtonsoft.Json;
+
+namespace Hyperledger.Aries.Features.Pex.Models
+{
+    /// <summary>
+    ///     Represents the claim format, encapsulating supported algorithms.
+    /// </summary>
+    public class Format
+    {
+        /// <summary>
+        ///     Gets the names of supported algorithms.
+        /// </summary>
+        [JsonProperty("alg")]
+        public string[] Alg { get; private set; } = null!;
+        
+        /// <summary>
+        ///     Gets the names of supported proof types.
+        /// </summary>
+        [JsonProperty("proof_type")]
+        public string[] ProofTypes { get; private set; } = null!;
+    }
+}

--- a/src/Hyperledger.Aries/Features/Pex/Models/InputDescriptor.cs
+++ b/src/Hyperledger.Aries/Features/Pex/Models/InputDescriptor.cs
@@ -13,22 +13,22 @@ namespace Hyperledger.Aries.Features.Pex.Models
         ///     Gets or sets the constraints for the input descriptor.
         ///     It defines conditions that must be met for the input.
         /// </summary>
-        [JsonProperty("constraints")]
+        [JsonProperty("constraints", Required = Required.Always)]
         public Constraints Constraints { get; private set; } = null!;
 
         /// <summary>
-        ///     Gets or sets the format of the input descriptor.
+        ///     Gets or sets the formats of the input descriptor.
         ///     This property is optional.
         /// </summary>
         [JsonProperty("format")]
-        public Format? Format { get; private set; }
+        public Dictionary<string, Format> Formats { get; private set; } = null!;
 
         /// <summary>
         ///     Gets or sets the unique identifier for the input descriptor.
         ///     This MUST be a string that does not conflict with the id of another Input Descriptor Object
         ///     in the same Presentation Definition.
         /// </summary>
-        [JsonProperty("id")]
+        [JsonProperty("id", Required = Required.Always)]
         public string Id { get; private set; } = null!;
 
         /// <summary>
@@ -50,29 +50,6 @@ namespace Hyperledger.Aries.Features.Pex.Models
         /// </summary>
         [JsonProperty("group")]
         public string[]? Group { get; private set; }
-    }
-
-    /// <summary>
-    ///     Represents the format of the input descriptor, encapsulating supported algorithms.
-    /// </summary>
-    public class Format
-    {
-        /// <summary>
-        ///     Gets a dictionary of supported algorithms for the format, keyed by their designations
-        /// </summary>
-        public Dictionary<string, Algorithm> SupportedAlgorithms { get; private set; } = null!;
-    }
-
-    /// <summary>
-    ///     Represents the details of a supported algorithm.
-    /// </summary>
-    public class Algorithm
-    {
-        /// <summary>
-        ///     Gets the names of supported algorithms.
-        /// </summary>
-        [JsonProperty("alg")]
-        public string[] Alg { get; private set; } = null!;
     }
 
     /// <summary>

--- a/src/Hyperledger.Aries/Features/Pex/Models/PresentationDefinition.cs
+++ b/src/Hyperledger.Aries/Features/Pex/Models/PresentationDefinition.cs
@@ -1,7 +1,47 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
 namespace Hyperledger.Aries.Features.Pex.Models
 {
+    /// <summary>
+    /// Represents objects that articulate what proofs a Verifier requires
+    /// </summary>
     public class PresentationDefinition
     {
-        public InputDescriptor[] InputDescriptors { get; set; }
+        /// <summary>
+        /// This MUST be a string. The string SHOULD provide a unique ID for the desired context.
+        /// </summary>
+        [JsonProperty("id", Required = Required.Always)]
+        public string Id { get; private set; } = null!;
+
+        /// <summary>
+        /// Represents a collection of submission requirements
+        /// </summary>
+        [JsonProperty("submission_requirements")]
+        public SubmissionRequirement[] SubmissionRequirements { get; private set; } = null!;
+        
+        /// <summary>
+        /// Represents a collection of input descriptors.
+        /// </summary>
+        [JsonProperty("input_descriptors", Required = Required.Always)]
+        public InputDescriptor[] InputDescriptors { get; private set; } = null!;
+        
+        /// <summary>
+        /// This SHOULD be a human-friendly string intended to constitute a distinctive designation of the Presentation Definition.
+        /// </summary>
+        [JsonProperty("name")]
+        public string? Name { get; private set; }
+
+        /// <summary>
+        /// This MUST be a string that describes the purpose for which the Presentation Definition's inputs are being used for.
+        /// </summary>
+        public string? Purpose { get; private set; }
+        
+        /// <summary>
+        ///     Gets or sets the format of the presentation definition
+        ///     This property is optional.
+        /// </summary>
+        [JsonProperty("format")]
+        public Dictionary<string, Format> Formats { get; private set; } = null!;
     }
 }

--- a/src/Hyperledger.Aries/Features/Pex/Models/PresentationSubmission.cs
+++ b/src/Hyperledger.Aries/Features/Pex/Models/PresentationSubmission.cs
@@ -1,7 +1,28 @@
+using Newtonsoft.Json;
+
 namespace Hyperledger.Aries.Features.Pex.Models
 {
+    /// <summary>
+    /// Represents objects embedded within target Claim negotiation formats that express how the inputs presented as proofs to a Verifier are provided in accordance with the requirements specified in a Presentation Definition.
+    /// </summary>
     public class PresentationSubmission
     {
+        /// <summary>
+        /// This MUST be a unique identifier, such as a UUID.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; internal set; } = null!;
         
+        /// <summary>
+        /// This MUST be the id value of a valid Presentation Definition.
+        /// </summary>
+        [JsonProperty("definition_id")]
+        public string DefinitionId { get; internal set; } = null!;
+        
+        /// <summary>
+        /// This MUST be the id value of a valid Presentation Definition.
+        /// </summary>
+        [JsonProperty("descriptor_map")]
+        public Descriptor[] DescriptorMap { get; internal set; } = null!;
     }
 }

--- a/src/Hyperledger.Aries/Features/Pex/Models/SubmissionRequirement.cs
+++ b/src/Hyperledger.Aries/Features/Pex/Models/SubmissionRequirement.cs
@@ -24,7 +24,7 @@ namespace Hyperledger.Aries.Features.Pex.Models
         ///     This property must contain a group string matching one of the group strings
         ///     specified for one or more Input Descriptor Objects.
         /// </remarks>
-        [JsonProperty("from")]
+        [JsonProperty("from", Required = Required.Always)]
         public string From { get; private set; } = null!;
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace Hyperledger.Aries.Features.Pex.Models
         /// <remarks>
         ///     According to the HAIP, this property must be "pick".
         /// </remarks>
-        [JsonProperty("rule")]
+        [JsonProperty("rule", Required = Required.Always)]
         public string Rule { get; private set; } = null!;
 
         /// <summary>

--- a/src/Hyperledger.Aries/Features/Pex/Services/IPexService.cs
+++ b/src/Hyperledger.Aries/Features/Pex/Services/IPexService.cs
@@ -3,10 +3,24 @@ using Hyperledger.Aries.Features.Pex.Models;
 
 namespace Hyperledger.Aries.Features.Pex.Services
 {
+    /// <summary>
+    /// Pex Service.
+    /// </summary>
     public interface IPexService
     {
-        Task<PresentationDefinition> ParsePresentationDefinition(string presentationDefinition);
+        /// <summary>
+        /// Parses the presentation definition.
+        /// </summary>
+        /// <param name="presentationDefinitionJson">The JSON representation of a presentation definition.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the PresentationDefinition.</returns>
+        Task<PresentationDefinition> ParsePresentationDefinition(string presentationDefinitionJson);
   
-        Task<PresentationSubmission> CreatePresentationSubmission(PresentationDefinition presentationDefinition, CredentialDescriptor[] credentials);
+        /// <summary>
+        /// Creates a presentation submission.
+        /// </summary>
+        /// <param name="presentationDefinition">The presentation definition.</param>
+        /// <param name="credentialDescriptors">The credential descriptors.</param>
+        /// <returns></returns>
+        Task<PresentationSubmission> CreatePresentationSubmission(PresentationDefinition presentationDefinition, CredentialDescriptor[] credentialDescriptors);
     }
 }

--- a/src/Hyperledger.Aries/Features/Pex/Services/PexService.cs
+++ b/src/Hyperledger.Aries/Features/Pex/Services/PexService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Hyperledger.Aries.Features.Pex.Models;
+using Newtonsoft.Json;
+
+namespace Hyperledger.Aries.Features.Pex.Services
+{
+    /// <inheritdoc />
+    public class PexService : IPexService
+    {
+        /// <inheritdoc />
+        public Task<PresentationDefinition> ParsePresentationDefinition(string presentationDefinitionJson)
+        {
+            var presentationDefinition = JsonConvert.DeserializeObject<PresentationDefinition>(presentationDefinitionJson);
+            return Task.FromResult(presentationDefinition!);
+        }
+
+        /// <inheritdoc />
+        public Task<PresentationSubmission> CreatePresentationSubmission(PresentationDefinition presentationDefinition, CredentialDescriptor[] credentialDescriptors)
+        {
+            var inputDescriptorIds = presentationDefinition.InputDescriptors.Select(x => x.Id);
+            if (!credentialDescriptors.Select(x => x.Id).All(inputDescriptorIds.Contains))
+                throw new ArgumentException("Missing descriptors for given input descriptors in presentation definition.", nameof(credentialDescriptors));
+            
+            var presentationSubmission = new PresentationSubmission
+            {
+                Id = Guid.NewGuid().ToString(),
+                DefinitionId = presentationDefinition.Id,
+                DescriptorMap = credentialDescriptors.Cast<Descriptor>().ToArray()
+            };
+            
+            return Task.FromResult(presentationSubmission);
+        }
+    }
+}

--- a/test/Hyperledger.Aries.Tests/Extensions/ObjectExtensions.cs
+++ b/test/Hyperledger.Aries.Tests/Extensions/ObjectExtensions.cs
@@ -6,7 +6,7 @@ namespace Hyperledger.Aries.Tests.Extensions
 {
     public static class ObjectExtensions
     {
-        public static void PrivateSet<T, TProperty>(this T member, Expression<Func<T, TProperty>> property, object value)
+        public static void PrivateSet<T, TProperty>(this T member, Expression<Func<T, TProperty>> property, TProperty value)
         {
             var name = ((MemberExpression)property.Body).Member.Name;
         

--- a/test/Hyperledger.Aries.Tests/Features/Pex/Models/Can_Create_Presentation_Submission.json
+++ b/test/Hyperledger.Aries.Tests/Features/Pex/Models/Can_Create_Presentation_Submission.json
@@ -1,0 +1,117 @@
+{
+    "id": "123",
+    "name": "Parse example",
+    "input_descriptors": [
+        {
+            "id": "citizenship_input_1",
+            "name": "EU Driver's License",
+            "group": [
+                "A"
+            ],
+            "format": {
+                "jwt_vc": {
+                    "alg": ["ES256K", "ES384"]
+                }
+            },
+            "constraints": {
+                "fields": [
+                    {
+                        "path": [
+                            "$.credentialSchema.id",
+                            "$.vc.credentialSchema.id"
+                        ],
+                        "filter": {
+                            "type": "string",
+                            "const": "https://eu.com/claims/DriversLicense.json"
+                        }
+                    },
+                    {
+                        "path": [
+                            "$.issuer",
+                            "$.vc.issuer",
+                            "$.iss"
+                        ],
+                        "purpose": "We can only accept digital driver's licenses issued by national authorities of member states or trusted notarial auditors.",
+                        "filter": {
+                            "type": "string",
+                            "pattern": "did:example:gov1|did:example:gov2"
+                        }
+                    },
+                    {
+                        "path": [
+                            "$.credentialSubject.dob",
+                            "$.vc.credentialSubject.dob",
+                            "$.dob"
+                        ],
+                        "filter": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "id": "citizenship_input_2",
+            "name": "US Passport",
+            "group": [
+                "A"
+            ],
+            "format": {
+                "jwt_vc": {
+                    "alg": ["ES256K", "ES384"]
+                }
+            },
+            "constraints": {
+                "fields": [
+                    {
+                        "path": [
+                            "$.credentialSchema.id",
+                            "$.vc.credentialSchema.id"
+                        ],
+                        "filter": {
+                            "type": "string",
+                            "const": "hub://did:foo:123/Collections/schema.us.gov/passport.json"
+                        }
+                    },
+                    {
+                        "path": [
+                            "$.credentialSubject.birth_date",
+                            "$.vc.credentialSubject.birth_date",
+                            "$.birth_date"
+                        ],
+                        "filter": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "format": {
+        "jwt": {
+            "alg": ["EdDSA", "ES256K", "ES384"]
+        },
+        "jwt_vc": {
+            "alg": ["ES256K", "ES384"]
+        },
+        "jwt_vp": {
+            "alg": ["EdDSA", "ES256K"]
+        },
+        "ldp_vc": {
+            "proof_type": [
+                "JsonWebSignature2020",
+                "Ed25519Signature2018",
+                "EcdsaSecp256k1Signature2019",
+                "RsaSignature2018"
+            ]
+        },
+        "ldp_vp": {
+            "proof_type": ["Ed25519Signature2018"]
+        },
+        "ldp": {
+            "proof_type": ["RsaSignature2018"]
+        }
+    }
+}

--- a/test/Hyperledger.Aries.Tests/Features/Pex/Models/Can_Parse_Presentation_Definition.json
+++ b/test/Hyperledger.Aries.Tests/Features/Pex/Models/Can_Parse_Presentation_Definition.json
@@ -1,0 +1,113 @@
+{
+    "id": "123",
+    "name": "Parse example",
+    "submission_requirements": [{
+        "name": "Citizenship Information",
+        "rule": "pick",
+        "count": 1,
+        "from": "A"
+    }],
+    "input_descriptors": [
+        {
+            "id": "citizenship_input_1",
+            "name": "EU Driver's License",
+            "group": [
+                "A"
+            ],
+            "constraints": {
+                "fields": [
+                    {
+                        "path": [
+                            "$.credentialSchema.id",
+                            "$.vc.credentialSchema.id"
+                        ],
+                        "filter": {
+                            "type": "string",
+                            "const": "https://eu.com/claims/DriversLicense.json"
+                        }
+                    },
+                    {
+                        "path": [
+                            "$.issuer",
+                            "$.vc.issuer",
+                            "$.iss"
+                        ],
+                        "purpose": "We can only accept digital driver's licenses issued by national authorities of member states or trusted notarial auditors.",
+                        "filter": {
+                            "type": "string",
+                            "pattern": "did:example:gov1|did:example:gov2"
+                        }
+                    },
+                    {
+                        "path": [
+                            "$.credentialSubject.dob",
+                            "$.vc.credentialSubject.dob",
+                            "$.dob"
+                        ],
+                        "filter": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "id": "citizenship_input_2",
+            "name": "US Passport",
+            "group": [
+                "A"
+            ],
+            "constraints": {
+                "fields": [
+                    {
+                        "path": [
+                            "$.credentialSchema.id",
+                            "$.vc.credentialSchema.id"
+                        ],
+                        "filter": {
+                            "type": "string",
+                            "const": "hub://did:foo:123/Collections/schema.us.gov/passport.json"
+                        }
+                    },
+                    {
+                        "path": [
+                            "$.credentialSubject.birth_date",
+                            "$.vc.credentialSubject.birth_date",
+                            "$.birth_date"
+                        ],
+                        "filter": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "format": {
+        "jwt": {
+            "alg": ["EdDSA", "ES256K", "ES384"]
+        },
+        "jwt_vc": {
+            "alg": ["ES256K", "ES384"]
+        },
+        "jwt_vp": {
+            "alg": ["EdDSA", "ES256K"]
+        },
+        "ldp_vc": {
+            "proof_type": [
+                "JsonWebSignature2020",
+                "Ed25519Signature2018",
+                "EcdsaSecp256k1Signature2019",
+                "RsaSignature2018"
+            ]
+        },
+        "ldp_vp": {
+            "proof_type": ["Ed25519Signature2018"]
+        },
+        "ldp": {
+            "proof_type": ["RsaSignature2018"]
+        }
+    }
+}

--- a/test/Hyperledger.Aries.Tests/Features/Pex/Models/PexTestsDataProvider.cs
+++ b/test/Hyperledger.Aries.Tests/Features/Pex/Models/PexTestsDataProvider.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Hyperledger.Aries.Tests.Features.Pex.Models
+{
+    public static class PexTestsDataProvider
+    {
+        public static string GetJsonForTestCase([CallerMemberName]string name = "")
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            var currentNamespace = typeof(PexTestsDataProvider).Namespace;
+            var resourceName = $"{currentNamespace}.{name}.json";
+
+            using var stream = assembly.GetManifestResourceStream(resourceName);
+            if (stream == null)
+            {
+                throw new InvalidOperationException($"Could not find resource with name {resourceName}");
+            }
+
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+    }
+}

--- a/test/Hyperledger.Aries.Tests/Features/Pex/Models/Throws_Exception_When_Descriptors_Are_Missing.json
+++ b/test/Hyperledger.Aries.Tests/Features/Pex/Models/Throws_Exception_When_Descriptors_Are_Missing.json
@@ -1,0 +1,117 @@
+{
+    "id": "123",
+    "name": "Parse example",
+    "input_descriptors": [
+        {
+            "id": "citizenship_input_1",
+            "name": "EU Driver's License",
+            "group": [
+                "A"
+            ],
+            "format": {
+                "jwt_vc": {
+                    "alg": ["ES256K", "ES384"]
+                }
+            },
+            "constraints": {
+                "fields": [
+                    {
+                        "path": [
+                            "$.credentialSchema.id",
+                            "$.vc.credentialSchema.id"
+                        ],
+                        "filter": {
+                            "type": "string",
+                            "const": "https://eu.com/claims/DriversLicense.json"
+                        }
+                    },
+                    {
+                        "path": [
+                            "$.issuer",
+                            "$.vc.issuer",
+                            "$.iss"
+                        ],
+                        "purpose": "We can only accept digital driver's licenses issued by national authorities of member states or trusted notarial auditors.",
+                        "filter": {
+                            "type": "string",
+                            "pattern": "did:example:gov1|did:example:gov2"
+                        }
+                    },
+                    {
+                        "path": [
+                            "$.credentialSubject.dob",
+                            "$.vc.credentialSubject.dob",
+                            "$.dob"
+                        ],
+                        "filter": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "id": "citizenship_input_2",
+            "name": "US Passport",
+            "group": [
+                "A"
+            ],
+            "format": {
+                "jwt_vc": {
+                    "alg": ["ES256K", "ES384"]
+                }
+            },
+            "constraints": {
+                "fields": [
+                    {
+                        "path": [
+                            "$.credentialSchema.id",
+                            "$.vc.credentialSchema.id"
+                        ],
+                        "filter": {
+                            "type": "string",
+                            "const": "hub://did:foo:123/Collections/schema.us.gov/passport.json"
+                        }
+                    },
+                    {
+                        "path": [
+                            "$.credentialSubject.birth_date",
+                            "$.vc.credentialSubject.birth_date",
+                            "$.birth_date"
+                        ],
+                        "filter": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "format": {
+        "jwt": {
+            "alg": ["EdDSA", "ES256K", "ES384"]
+        },
+        "jwt_vc": {
+            "alg": ["ES256K", "ES384"]
+        },
+        "jwt_vp": {
+            "alg": ["EdDSA", "ES256K"]
+        },
+        "ldp_vc": {
+            "proof_type": [
+                "JsonWebSignature2020",
+                "Ed25519Signature2018",
+                "EcdsaSecp256k1Signature2019",
+                "RsaSignature2018"
+            ]
+        },
+        "ldp_vp": {
+            "proof_type": ["Ed25519Signature2018"]
+        },
+        "ldp": {
+            "proof_type": ["RsaSignature2018"]
+        }
+    }
+}

--- a/test/Hyperledger.Aries.Tests/Features/Pex/Services/PexServiceTests.cs
+++ b/test/Hyperledger.Aries.Tests/Features/Pex/Services/PexServiceTests.cs
@@ -1,13 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Hyperledger.Aries.Features.Pex.Models;
 using Hyperledger.Aries.Features.Pex.Services;
-using Hyperledger.Aries.Tests.Extensions;
 using Hyperledger.Aries.Tests.Features.Pex.Models;
-using Moq;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -81,31 +78,6 @@ namespace Hyperledger.Aries.Tests.Features.Pex.Services
                 presentationSubmission.DescriptorMap[i].Format.Should().Be(credentials[i].Format);
                 presentationSubmission.DescriptorMap[i].Path.Should().Be(credentials[i].Path);   
             }
-        }
-        
-        [Fact]
-        public async Task Throws_Exception_When_Descriptors_Are_Missing()
-        {
-            var inputDescriptor = new InputDescriptor();
-            inputDescriptor.PrivateSet(x => x.Id, Guid.NewGuid().ToString());
-            inputDescriptor.PrivateSet(x => x.Formats, new Dictionary<string, Format> { {"format-1", null }});
-            
-            var presentationDefinition = new PresentationDefinition();
-            presentationDefinition.PrivateSet(x => x.Id, Guid.NewGuid().ToString());
-            presentationDefinition.PrivateSet(x => x.InputDescriptors, new[] { inputDescriptor });
-            
-            var credentials = new CredentialDescriptor[]
-            {
-                new()
-                {
-                    Id = Guid.NewGuid().ToString(),
-                    CredentialId = Guid.NewGuid().ToString(),
-                    Format = presentationDefinition.InputDescriptors[0].Formats.First().Key,
-                    Path = "$.credentials[0]"
-                }
-            };
-
-            await Assert.ThrowsAsync<ArgumentException>(() => _pexService.CreatePresentationSubmission(presentationDefinition, credentials));
         }
     }
 }

--- a/test/Hyperledger.Aries.Tests/Features/Pex/Services/PexServiceTests.cs
+++ b/test/Hyperledger.Aries.Tests/Features/Pex/Services/PexServiceTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Hyperledger.Aries.Features.Pex.Models;
+using Hyperledger.Aries.Features.Pex.Services;
+using Hyperledger.Aries.Tests.Extensions;
+using Hyperledger.Aries.Tests.Features.Pex.Models;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Hyperledger.Aries.Tests.Features.Pex.Services
+{
+    public class PexServiceTests
+    {
+        private readonly PexService _pexService = new();
+
+        [Fact]
+        public async Task Can_Parse_Presentation_Definition()
+        {
+            var json = PexTestsDataProvider.GetJsonForTestCase();
+
+            var presentationDefinition = await _pexService.ParsePresentationDefinition(json);
+            
+            presentationDefinition.Id.Should().Be("123");
+            presentationDefinition.Name.Should().Be("Parse example");
+            presentationDefinition.SubmissionRequirements.Length.Should().Be(1);
+            presentationDefinition.SubmissionRequirements[0].Name.Should().Be("Citizenship Information");
+            presentationDefinition.InputDescriptors.Length.Should().Be(2);
+            presentationDefinition.InputDescriptors.Length.Should().Be(2);
+            presentationDefinition.InputDescriptors[0].Name.Should().Be("EU Driver's License");
+            presentationDefinition.InputDescriptors[0].Group!.Length.Should().Be(1);
+            presentationDefinition.InputDescriptors[0].Group![0].Should().Be("A");
+            presentationDefinition.InputDescriptors[0].Constraints.Fields!.Length.Should().Be(3);
+            presentationDefinition.InputDescriptors[0].Constraints.Fields![0].Path.Length.Should().Be(2);
+            presentationDefinition.InputDescriptors[0].Constraints.Fields![0].Path[0].Should().Be("$.credentialSchema.id");
+            presentationDefinition.InputDescriptors[1].Name.Should().Be("US Passport");
+            presentationDefinition.Formats.Count.Should().Be(6);
+            presentationDefinition.Formats.Keys.First().Should().Be("jwt");
+            presentationDefinition.Formats["jwt"].Alg.Length.Should().Be(3);
+            presentationDefinition.Formats["jwt"].Alg[2].Should().Be("ES384");
+            
+            presentationDefinition.Formats.Count.Should().Be(6);
+        }
+
+        [Fact]
+        public async Task Can_Create_Presentation_Submission()
+        {
+            var presentationDefinition = JsonConvert.DeserializeObject<PresentationDefinition>(PexTestsDataProvider.GetJsonForTestCase());
+            
+            var credentials = new CredentialDescriptor[]
+            {
+                new()
+                {
+                    Id = presentationDefinition.InputDescriptors[0].Id,
+                    CredentialId = Guid.NewGuid().ToString(),
+                    Format = presentationDefinition.InputDescriptors[0].Formats.First().Key,
+                    Path = "$.credentials[0]"
+                },
+                new()
+                {
+                    Id = presentationDefinition.InputDescriptors[1].Id,
+                    CredentialId = Guid.NewGuid().ToString(),
+                    Format = presentationDefinition.InputDescriptors[1].Formats.First().Key,
+                    Path = "$.credentials[1]"
+                },
+            };
+
+            
+            var presentationSubmission = await _pexService.CreatePresentationSubmission(presentationDefinition, credentials);
+
+            presentationSubmission.Id.Should().NotBeNullOrWhiteSpace();
+            presentationSubmission.DefinitionId.Should().Be(presentationDefinition.Id);
+            presentationSubmission.DescriptorMap.Length.Should().Be(credentials.Length);
+
+            for (var i = 0; i < presentationDefinition.InputDescriptors.Length; i++)
+            {
+                presentationSubmission.DescriptorMap[i].Id.Should().Be(presentationDefinition.InputDescriptors[i].Id);
+                presentationSubmission.DescriptorMap[i].Format.Should().Be(credentials[i].Format);
+                presentationSubmission.DescriptorMap[i].Path.Should().Be(credentials[i].Path);   
+            }
+        }
+        
+        [Fact]
+        public async Task Throws_Exception_When_Descriptors_Are_Missing()
+        {
+            var inputDescriptor = new InputDescriptor();
+            inputDescriptor.PrivateSet(x => x.Id, Guid.NewGuid().ToString());
+            inputDescriptor.PrivateSet(x => x.Formats, new Dictionary<string, Format> { {"format-1", null }});
+            
+            var presentationDefinition = new PresentationDefinition();
+            presentationDefinition.PrivateSet(x => x.Id, Guid.NewGuid().ToString());
+            presentationDefinition.PrivateSet(x => x.InputDescriptors, new[] { inputDescriptor });
+            
+            var credentials = new CredentialDescriptor[]
+            {
+                new()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    CredentialId = Guid.NewGuid().ToString(),
+                    Format = presentationDefinition.InputDescriptors[0].Formats.First().Key,
+                    Path = "$.credentials[0]"
+                }
+            };
+
+            await Assert.ThrowsAsync<ArgumentException>(() => _pexService.CreatePresentationSubmission(presentationDefinition, credentials));
+        }
+    }
+}

--- a/test/Hyperledger.Aries.Tests/Features/SdJwt/SdJwtVcHolderTests.cs
+++ b/test/Hyperledger.Aries.Tests/Features/SdJwt/SdJwtVcHolderTests.cs
@@ -47,7 +47,7 @@ namespace Hyperledger.Aries.Tests.Features.SdJwt
             var driverLicenseInputDescriptor = CreateInputDescriptor(
                 CreateConstraints(new[]
                     { CreateField("$.id", idFilter), CreateField("$.issuer"), CreateField("$.dateOfBirth") }),
-                CreateFormat(new[] { "ES256" }, "vc+sd-jwt"),
+                new Dictionary<string, Format> { {"vc+sd-jwt", CreateFormat(new[] { "ES256" }) }},
                 Guid.NewGuid().ToString(),
                 "EU Driver's License",
                 "We can only accept digital driver's licenses issued by national authorities of member states or trusted notarial auditors.",
@@ -55,7 +55,7 @@ namespace Hyperledger.Aries.Tests.Features.SdJwt
 
             var universityInputDescriptor = CreateInputDescriptor(
                 CreateConstraints(new[] { CreateField("$.degree") }),
-                CreateFormat(new[] { "ES256" }, "vc+sd-jwt"),
+                new Dictionary<string, Format> { {"vc+sd-jwt", CreateFormat(new[] { "ES256" }) }},
                 Guid.NewGuid().ToString(),
                 "University Degree",
                 "We can only accept digital university degrees.");
@@ -102,7 +102,7 @@ namespace Hyperledger.Aries.Tests.Features.SdJwt
                     CreateField("$.id"), CreateField("$.issuer"),
                     CreateField("$.dateOfBirth"), CreateField("$.name")
                 }),
-                CreateFormat(new[] { "ES256" }, "vc+sd-jwt"),
+                new Dictionary<string, Format> { {"vc+sd-jwt", CreateFormat(new[] { "ES256" }) }},
                 Guid.NewGuid().ToString(),
                 "EU Driver's License",
                 "We can only accept digital driver's licenses issued by national authorities of member states or trusted notarial auditors.");
@@ -140,7 +140,7 @@ namespace Hyperledger.Aries.Tests.Features.SdJwt
                 {
                     CreateField("$.id", idFilter), CreateField("$.issuer"), CreateField("$.dateOfBirth")
                 }),
-                CreateFormat(new[] { "ES256" }, "vc+sd-jwt"),
+                new Dictionary<string, Format> { {"vc+sd-jwt", CreateFormat(new[] { "ES256" }) }},
                 Guid.NewGuid().ToString(),
                 "EU Driver's License",
                 "We can only accept digital driver's licenses issued by national authorities of member states or trusted notarial auditors.");
@@ -215,28 +215,21 @@ namespace Hyperledger.Aries.Tests.Features.SdJwt
             return field;
         }
 
-        private static Format CreateFormat(string[] supportedAlg, string supportedFormat)
+        private static Format CreateFormat(string[] supportedAlg)
         {
-            var alg = new Algorithm();
-            alg.PrivateSet(x => x.Alg, supportedAlg);
-
             var format = new Format();
-            format.PrivateSet(x => x.SupportedAlgorithms,
-                new Dictionary<string, Algorithm>
-                {
-                    { supportedFormat, alg }
-                });
+            format.PrivateSet(x => x.Alg, supportedAlg);
 
             return format;
         }
 
-        private static InputDescriptor CreateInputDescriptor(Constraints constraints, Format format, string id,
+        private static InputDescriptor CreateInputDescriptor(Constraints constraints, Dictionary<string, Format> formats, string id,
             string name, string purpose, string[]? group = null)
         {
             var inputDescriptor = new InputDescriptor();
 
             inputDescriptor.PrivateSet(x => x.Constraints, constraints);
-            inputDescriptor.PrivateSet(x => x.Format, format);
+            inputDescriptor.PrivateSet(x => x.Formats, formats);
             inputDescriptor.PrivateSet(x => x.Id, id);
             inputDescriptor.PrivateSet(x => x.Name, name);
             inputDescriptor.PrivateSet(x => x.Purpose, purpose);

--- a/test/Hyperledger.Aries.Tests/Hyperledger.Aries.Tests.csproj
+++ b/test/Hyperledger.Aries.Tests/Hyperledger.Aries.Tests.csproj
@@ -37,4 +37,15 @@
     <ProjectReference Include="..\..\src\Hyperledger.Aries.TestHarness\Hyperledger.Aries.TestHarness.csproj" />
     <ProjectReference Include="..\..\src\Hyperledger.Aries.Payments.SovrinToken\Hyperledger.Aries.Payments.SovrinToken.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Remove="Features\Pex\Models\InputDescriptors.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Features\Pex\Models\Can_Create_Presentation_Submission.json" />
+    <EmbeddedResource Include="Features\Pex\Models\Can_Create_Presentation_Submission.json" />
+    <None Remove="Features\Pex\Models\Can_Parse_Presentation_Definition.json" />
+    <EmbeddedResource Include="Features\Pex\Models\Can_Parse_Presentation_Definition.json" />
+    <None Remove="Features\Pex\Models\Throws_Exception_When_Descriptors_Are_Missing.json" />
+    <EmbeddedResource Include="Features\Pex\Models\Throws_Exception_When_Descriptors_Are_Missing.json" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
#### Short description of what this resolves:
This PR adds a PexService which implements the PEX specs and respects HAIP. 
PEX specs: https://identity.foundation/presentation-exchange/spec/v2.0.0/
HAIP specs: https://vcstuff.github.io/oid4vc-haip-sd-jwt-vc/draft-oid4vc-haip-sd-jwt-vc.html#name-openid-for-verifiable-prese

#### Changes proposed in this pull request:
- parse a given presentation definition JSON
- create a presentation submission for an presentation defintion