### PR TITLE
refine EdgeProvisioningService

### DIFF
--- a/src/Hyperledger.Aries.Routing.Edge/IEdgeProvisioningService.cs
+++ b/src/Hyperledger.Aries.Routing.Edge/IEdgeProvisioningService.cs
@@ -8,5 +8,7 @@ namespace Hyperledger.Aries.Agents.Edge
     {
         Task ProvisionAsync(AgentOptions options, CancellationToken cancellationToken = default);
         Task ProvisionAsync(CancellationToken cancellationToken = default);
+        Task CreateMediatorConnectionAndInboxAsync(AgentOptions agentOptions, CancellationToken cancellationToken = default);
+        Task CreateMediatorConnectionAndInboxAsync(CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
**Short description of what this resolves:**
This PR adds another method to the EdgeProvisioningService which can be used to create a MediatorConnection and Inbox if a Wallet is already present.

**Changes proposed in this pull request:**
- Adds method CreateMediatorConnectionAndInboxAsync
- Refactoring.